### PR TITLE
Removed maven publishing script in favor of jitpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,18 +80,10 @@ class UserMapper : Mapper<User>() {
 ```
 
 ## Download
-```gradle
-// This is usually in the top-level build.gradle file
-allprojects {
-    repositories {
-        jcenter() // Since the JAR lives in Bintray's jCenter
-    }
-}
+Jitpack the code,
 
-dependencies {
-    compile "com.jayrave:moshi-pristine-models:$version"
-}
-```
+Visit [https://jitpack.io/#jayrave/moshi-pristine-models](https://jitpack.io/#jayrave/moshi-pristine-models) and get the latest version
+
 
 ## Check this out
 If you like keeping your models clean, you may be interested in checking out another library => [Falkon](https://github.com/jayrave/falkon) (Disclaimer: I am the author), which helps to keep your models free of database/ORM specific annotations. Like this library, Falkon also enables to programmatically define the mapping between models & database records 

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,9 @@ buildscript {
     repositories {
         google()
         mavenCentral()
-        jcenter()
     }
 
     dependencies {
-        classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
@@ -25,7 +23,6 @@ targetCompatibility = JavaVersion.VERSION_1_6
 repositories {
     google()
     mavenCentral()
-    jcenter()
 }
 
 
@@ -42,120 +39,3 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.github.salomonbrys.kotson:kotson:2.5.0'
 }
-
-
-// ========================================= Publishing ============================================
-
-apply plugin: 'maven'
-apply plugin: 'com.jfrog.bintray'
-
-
-ext {
-    publishedGroupId = 'com.jayrave'
-    publishedArtifactId = 'moshi-pristine-models'
-
-    bintrayRepo = 'kotlin'
-    bintrayName = publishedArtifactId
-
-    libraryName = 'Moshi Pristine Models'
-    libraryVersionName = '1.0.0'
-    libraryDescription = 'Moshi add-on to programmatically define mapping between models & JSON'
-
-    siteUrl = 'https://github.com/jayrave/moshi-pristine-models'
-    gitUrl = 'https://github.com/jayrave/moshi-pristine-models.git'
-    issuesUrl = 'https://github.com/jayrave/moshi-pristine-models/issues'
-
-    developerId = 'jayrave'
-    developerName = 'Jayanthan Raveendiran'
-    developerEmail = 'jayanthan.raveendiran@gmail.com'
-
-    licenseName = 'The Apache Software License, Version 2.0'
-    licenseUrl = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-    allLicenses = ['Apache-2.0']
-}
-
-
-install {
-    repositories.mavenInstaller {
-        pom {
-            project {
-                packaging 'jar'
-                groupId publishedGroupId
-                artifactId publishedArtifactId
-
-                name libraryName
-                description libraryDescription
-                url siteUrl
-
-                licenses {
-                    license {
-                        name licenseName
-                        url licenseUrl
-                    }
-                }
-
-                developers {
-                    developer {
-                        id developerId
-                        name developerName
-                        email developerEmail
-                    }
-                }
-
-                scm {
-                    connection gitUrl
-                    developerConnection gitUrl
-                    url siteUrl
-                }
-            }
-        }
-    }
-}
-
-
-task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
-    from sourceSets.main.allSource
-}
-
-
-artifacts {
-    archives sourcesJar
-}
-
-
-group = publishedGroupId
-version = libraryVersionName
-
-
-bintray {
-    File propertiesFile = project.rootProject.file('local.properties')
-
-    if (propertiesFile.exists()) {
-        Properties properties = new Properties()
-        properties.load(propertiesFile.newDataInputStream())
-
-        user = properties['bintray.user']
-        key = properties['bintray.apikey']
-        publish = true
-        configurations = ['archives']
-
-        pkg {
-            repo = bintrayRepo
-            name = bintrayName
-            desc = libraryDescription
-            websiteUrl = siteUrl
-            issueTrackerUrl = issuesUrl
-            vcsUrl = gitUrl
-            licenses = allLicenses
-            publicDownloadNumbers = true
-            version {
-                name = libraryVersionName
-                released = new Date()
-            }
-        }
-    }
-}
-
-
-// ========================================= Publishing ============================================


### PR DESCRIPTION
Updating the library to the latest commit results in unresolved dependency due to the [unsuccessful](https://jitpack.io/#jayrave/moshi-pristine-models) publishing script.  Hence it is removed in-favor of jitpack.